### PR TITLE
Fix `node.yaml` not being recognized

### DIFF
--- a/ansible-provisioning/ansible.cfg
+++ b/ansible-provisioning/ansible.cfg
@@ -1,2 +1,0 @@
-[defaults]
-inventory = inventory.cfg

--- a/ansible-provisioning/ctrl.yaml
+++ b/ansible-provisioning/ctrl.yaml
@@ -1,6 +1,6 @@
 # ctrl.yaml
 ---
-- hosts: ctrl
+- hosts: controller
   become: yes
   vars:
     # Pass variables from Vagrant to Ansible

--- a/ansible-provisioning/inventory.cfg
+++ b/ansible-provisioning/inventory.cfg
@@ -1,6 +1,10 @@
-[ctrl]
-192.168.56.100
+[controller]
+ctrl ansible_host=192.168.56.100
 
 [nodes]
-192.168.56.101
-192.168.56.102
+node-1 ansible_host=192.168.56.101
+node-2 ansible_host=192.168.56.102
+
+[all:children]
+controller
+nodes


### PR DESCRIPTION
There was a formatting mistake with the `inventory.cfg`, and a few lines missing in `Vagrantfile`, which enable Vagrant to see the inventory contents correctly. This PR fixes that.

Closes #17 