### PR TITLE
Alerting part

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ cd ./sentiment-app-chart
 helm dependency build
 cd ..
 
-# Install the Helm chart
-helm install sentiment-app ./sentiment-app-chart --set monitoring.enabled=<value>
+# Install the Helm chart (optionally, Gmail inbox and App password https://support.google.com/accounts/answer/185833?hl=en are needed for receiving alerts)
+helm install sentiment-app ./sentiment-app-chart --set monitoring.enabled=true --set gmailEmail=<value>@gmail.com --set emailPassword=<value>
 
 # Verify the deployment
 kubectl get pods
@@ -225,10 +225,16 @@ If monitoring is enabled you can run the following command to open the port-forw
 ```bash
 kubectl port-forward -n kube-prometheus-stack svc/kube-prometheus-stack-prometheus 9090:9090
 ```
+or alternatively
+`minikube service sentiment-app-kube-prometh-prometheus --url`
 This can then be accessed at [http://127.0.0.1:9090](http://localhost:9090)
 
 
 The grafana UI can be accessed at [http://grafana.local](http://grafana.local) with username: admin, password: prom-operator
+
+In order to see alert manager dashboard, call `minikube service sentiment-app-kube-prometh-alertmanager --url`.
+Submissions can be simulated easily with the command:
+`for i in `seq 1 100`; do curl 'http://127.0.0.1:<app service port>/api/submit' -H 'Content-Type: application/json' --data-raw '{"text":"review"}'; done`
 
 ##### Uninstalling the Chart
 

--- a/sentiment-app-chart/templates/alert-manager.yaml
+++ b/sentiment-app-chart/templates/alert-manager.yaml
@@ -1,39 +1,23 @@
 {{- if .Values.monitoring.enabled }}
-apiVersion: monitoring.coreos.com/v1alpha1 
+apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:
   name: {{ include "sentiment-app-chart.fullname" . }}-am-config
   labels:
-    alertmanagerConfig: "true" 
-    release: {{ .Release.Name }} 
+    release: {{ .Release.Name }}
 spec:
   route:
-    receiver: 'null-receiver'
-    groupBy: ['alertname'] 
-    groupWait: 30s
-    groupInterval: 1m
-    repeatInterval: 1m
-    routes:
-    - receiver: 'gmail-notifications' 
-      matchers:
-      - name: "app" 
-        value: {{ include "sentiment-app-chart.name" . }} 
-        matchType: "="
-      continue: false
+    receiver: 'gmail-notifications'
   receivers:
-  - name: 'gmail-notifications' 
+  - name: 'gmail-notifications'
     emailConfigs:
-    - to: 'group5remla@gmail.com'
-      from: 'group5remla@gmail.com' 
-      smarthost: 'smtp.gmail.com:587'
-      authUsername: 'group5remla@gmail.com' 
+    - to: "{{ .Values.gmailEmail }}"
+      from: "{{ .Values.gmailEmail }}"
+      smarthost: smtp.gmail.com:587
+      authUsername: "{{ .Values.gmailEmail }}"
       authPassword:
-        name: gmail-smtp-credentials  
-        key: appPassword  
-      authIdentity: 'group5remla@gmail.com'
-      headers :
-        - key: subject
-          value: "Warning"
-      text: "Testing AlertManager"
-  - name: 'null-receiver' 
+        name: gmail-smtp-credentials
+        key: appPassword
+      authIdentity: "{{ .Values.gmailEmail }}"
+      sendResolved: true
 {{- end }}

--- a/sentiment-app-chart/templates/gmail-secret.yaml
+++ b/sentiment-app-chart/templates/gmail-secret.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: gmail-smtp-credentials
-  namespace: {{ .Release.Namespace }} 
-type: Opaque
+  namespace: {{ .Release.Namespace }}
 stringData:
-  appPassword: qydpjahmvyzqmzqt
+  appPassword: "{{ .Values.emailPassword }}"

--- a/sentiment-app-chart/templates/prometheus-rules.yaml
+++ b/sentiment-app-chart/templates/prometheus-rules.yaml
@@ -10,10 +10,13 @@ spec:
   - name: {{ include "sentiment-app-chart.name" . }}.rules
     rules:
     - alert: RapidSubmissionIncrease
-      expr: |
-        increase(total_submissions_total{sentiment="true"}[1m]) >= 5
-      for: 0m
+      expr: rate(total_submissions_total[60s]) > 0.25
+      for: 2m
+      annotations:
+        title: 'the service receives more than 15 submissions per minute for two minutes straight'
+        description: 'the service receives more than 15 submissions per minute for two minutes straight'
       labels:
         severity: warning
         app: {{ include "sentiment-app-chart.name" . }}
+        namespace: 'default'
 {{- end }}

--- a/sentiment-app-chart/values.yaml
+++ b/sentiment-app-chart/values.yaml
@@ -16,7 +16,7 @@ monitoring:
   enabled: false
   scrapeInterval: 15s
 
-gmailEmail: @gmail.com
+gmailEmail: "@gmail.com"
 emailPassword: value
 
 grafana:

--- a/sentiment-app-chart/values.yaml
+++ b/sentiment-app-chart/values.yaml
@@ -16,6 +16,9 @@ monitoring:
   enabled: false
   scrapeInterval: 15s
 
+gmailEmail: @gmail.com
+emailPassword: value
+
 grafana:
   ingress:
     host: grafana.local


### PR DESCRIPTION
Helpful tool for understanding alert routing visually: https://www.prometheus.io/webtools/alerting/routing-tree-editor/ . There wasn't much of clear guidance how to setup alerts on prometheus stack https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack , apparently prometheus operator is used underhood and it has some docs https://prometheus-operator.dev/docs/developer/alerting/ . Another useful resource was https://grafana.com/blog/2020/02/25/step-by-step-guide-to-setting-up-prometheus-alertmanager-with-slack-pagerduty-and-gmail/ .