### PR TITLE
Istio Traffic management

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,8 @@ Links to the repositories used in this project:
 
 ✅ Assignment 4
 
+✅ Assignment 5
+
 ### Use of Generative AI
 
 We used generative AI in the following ways:
@@ -342,4 +344,4 @@ We used generative AI in the following ways:
 - **model-service**: For model-service, ChatGPT was used to understand what Dockerfiles and release.yml files are, and what they should contain. Copilot was used to help with making environment variables that are used in the model_utils.py and service.py files. It was also used to speed up repetitive tasks, like downloading the CountVectorizer model the same way that the trained model is downloaded. It was also used to help with writing the README.md file.
 - **lib-ml**: In lib-ml, Gemini was used to help determine the needed dependencies for the pyproject.toml file.
 - **app**: For the frontend, ChatGPT was only used for trivial and repetitive tasks. Examples include: adding try/catch blocks to code, adding console.log statements to code and defining datatypes in TypeScript as specified by me etc.
-- **operation**: For operation, GitHub Copilot was used to help with writing the README.md file. It was also used to help with understanding how `Vagrantfile works`, especially in combination with Ansible. For steps 1 - 5, it was used to help with understanding the setup of the Ansible `general.yaml` playbook. For steps 11-15 we used ChatGPT to enhance our personal understanding of how to specify things in the .yaml file, we read the documentation and then challenged our belief with ChatGPT to make sure we didn't miss any subtleties. For the Helm chart, we used ChatGPT to help understand the structure of the chart and how to use it. We also used it to help with writing the README.md file. For Assignment 5, ChatGPT was used to help with adding a section to the README.md file about how to use Istio with the Helm chart.
+- **operation**: For operation, GitHub Copilot was used to help with writing the README.md file. It was also used to help with understanding how `Vagrantfile` works, especially in combination with Ansible. For steps 1 - 5, it was used to help with understanding the setup of the Ansible `general.yaml` playbook. For steps 11-15 we used ChatGPT to enhance our personal understanding of how to specify things in the .yaml file, we read the documentation and then challenged our belief with ChatGPT to make sure we didn't miss any subtleties. For the Helm chart, we used ChatGPT to help understand the structure of the chart and how to use it. We also used it to help with writing the `README.md` file. For Assignment 5, ChatGPT was used to help with adding a section to the `README.md` file about how to use Istio with the Helm chart.

--- a/README.md
+++ b/README.md
@@ -256,6 +256,63 @@ code review and is checked in to a repository
 ML Infra here: https://github.com/remla25-team5/model-training with pytest
 Monitoring: rubric with Prometheus in operations + code in app to measure if error rate gets worse than a set number
 
+## Assignment 5
+
+### Running the Helm Chart with Istio
+
+After deploying with Helm (either on Minikube or the Vagrant-based Kubernetes cluster), Istio’s IngressGateway handles traffic routing.
+
+Ensure you have Istio installed in your cluster. If not, follow the [Istio installation guide](https://istio.io/latest/docs/setup/getting-started/).
+
+#### Checking the Istio Ingress Gateway IP on Minikube
+
+Istio routes traffic through its IngressGateway. To check the **Ingress Gateway’s IP address**, run:
+
+```bash
+minikube service list
+```
+
+This will expose the IP of the `istio-ingressgateway` service, which is what you’ll use to access your app. Open the second URL (the URL with the `http2/80` target port) under the `istio-ingressgateway` service in your browser.
+
+#### Testing with Postman or Curl
+
+✅ **Access the app normally (no experiment header):**
+
+* Open your browser and navigate to `http://<GATEWAY_IP>`.
+* Or use curl:
+
+  ```bash
+  curl http://<GATEWAY_IP>
+  ```
+
+✅ **Test experiment traffic (header-based sticky sessions):**
+If you want to force a user into the **new version** (`v2`) of the app, use the header `x-experiment: true`.
+For example, using curl:
+
+```bash
+curl -H "x-experiment: true" http://<GATEWAY_IP>
+```
+
+You can also test with **Postman**:
+
+* Set the URL: `http://<GATEWAY_IP>`
+* In the Headers tab, add:
+
+  ```
+  Key: x-experiment
+  Value: true
+  ```
+* Send the request to see responses from **v2**.
+
+#### 90/10 Canary Split Testing
+
+If no header is present (`x-experiment` not sent), Istio **dynamically splits traffic 90/10**:
+
+* **90%** of users will be routed to `v1`.
+* **10%** will see `v2`.
+
+You can verify this by repeatedly refreshing the page or sending multiple curl requests without the header.
+
 ## Repositories
 
 Links to the repositories used in this project:
@@ -285,4 +342,4 @@ We used generative AI in the following ways:
 - **model-service**: For model-service, ChatGPT was used to understand what Dockerfiles and release.yml files are, and what they should contain. Copilot was used to help with making environment variables that are used in the model_utils.py and service.py files. It was also used to speed up repetitive tasks, like downloading the CountVectorizer model the same way that the trained model is downloaded. It was also used to help with writing the README.md file.
 - **lib-ml**: In lib-ml, Gemini was used to help determine the needed dependencies for the pyproject.toml file.
 - **app**: For the frontend, ChatGPT was only used for trivial and repetitive tasks. Examples include: adding try/catch blocks to code, adding console.log statements to code and defining datatypes in TypeScript as specified by me etc.
-- **operation**: For operation, GitHub Copilot was used to help with writing the README.md file. It was also used to help with understanding how `Vagrantfile works`, especially in combination with Ansible. For steps 1 - 5, it was used to help with understanding the setup of the Ansible `general.yaml` playbook. For steps 11-15 we used ChatGPT to enhance our personal understanding of how to specify things in the .yaml file, we read the documentation and then challenged our belief with ChatGPT to make sure we didn't miss any subtleties. For the Helm chart, we used ChatGPT to help understand the structure of the chart and how to use it. We also used it to help with writing the README.md file.
+- **operation**: For operation, GitHub Copilot was used to help with writing the README.md file. It was also used to help with understanding how `Vagrantfile works`, especially in combination with Ansible. For steps 1 - 5, it was used to help with understanding the setup of the Ansible `general.yaml` playbook. For steps 11-15 we used ChatGPT to enhance our personal understanding of how to specify things in the .yaml file, we read the documentation and then challenged our belief with ChatGPT to make sure we didn't miss any subtleties. For the Helm chart, we used ChatGPT to help understand the structure of the chart and how to use it. We also used it to help with writing the README.md file. For Assignment 5, ChatGPT was used to help with adding a section to the README.md file about how to use Istio with the Helm chart.

--- a/sentiment-app-chart/templates/app-deployment.yaml
+++ b/sentiment-app-chart/templates/app-deployment.yaml
@@ -1,24 +1,68 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "sentiment-app-chart.fullname" . }}-app
+  name: {{ include "sentiment-app-chart.fullname" . }}-app-v1
   labels:
     {{- include "sentiment-app-chart.labels" . | nindent 4 }}
+    version: v1
 spec:
   replicas: {{ .Values.replica_count }}
   selector:
     matchLabels:
       app: {{ include "sentiment-app-chart.fullname" . }}-app
       {{- include "sentiment-app-chart.selectorLabels" . | nindent 6 }}
+      version: v1
   template:
     metadata:
       labels:
         app: {{ include "sentiment-app-chart.fullname" . }}-app
         {{- include "sentiment-app-chart.selectorLabels" . | nindent 8 }}
+        version: v1
     spec:
       containers:
         - name: {{ include "sentiment-app-chart.fullname" . }}-app
           image: "{{ .Values.app.image }}:{{ .Values.app.tag }}"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: {{ .Values.app.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "sentiment-app-chart.fullname" . }}-app-env
+            - secretRef:
+                name: {{ include "sentiment-app-chart.fullname" . }}-app-secret
+          volumeMounts:
+            - name: shared-data
+              mountPath: /mnt/shared
+      volumes:
+        - name: shared-data
+          hostPath:
+            path: /mnt/shared
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sentiment-app-chart.fullname" . }}-app-v2
+  labels:
+    {{- include "sentiment-app-chart.labels" . | nindent 4 }}
+    version: v2
+spec:
+  replicas: {{ .Values.replica_count }}
+  selector:
+    matchLabels:
+      app: {{ include "sentiment-app-chart.fullname" . }}-app
+      {{- include "sentiment-app-chart.selectorLabels" . | nindent 6 }}
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: {{ include "sentiment-app-chart.fullname" . }}-app
+        {{- include "sentiment-app-chart.selectorLabels" . | nindent 8 }}
+        version: v2
+    spec:
+      containers:
+        - name: {{ include "sentiment-app-chart.fullname" . }}-app
+          image: "{{ .Values.app.image }}:{{ .Values.app.tagv2 }}"
           imagePullPolicy: Always
           ports:
             - containerPort: {{ .Values.app.port }}

--- a/sentiment-app-chart/templates/app-destination-rule.yaml
+++ b/sentiment-app-chart/templates/app-destination-rule.yaml
@@ -2,9 +2,9 @@ apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata: { name: {{ include "sentiment-app-chart.fullname" . }}-app-dr }
 spec:
-host: {{ include "sentiment-app-chart.fullname" . }}-app
-subsets:
-- name: v1
-labels: { version: v1 }
-- name: v2
-labels: { version: v2 }
+    host: {{ include "sentiment-app-chart.fullname" . }}-app
+    subsets:
+    - name: v1
+      labels: { version: v1 }
+    - name: v2
+      labels: { version: v2 }

--- a/sentiment-app-chart/templates/app-destination-rule.yaml
+++ b/sentiment-app-chart/templates/app-destination-rule.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata: { name: {{ include "sentiment-app-chart.fullname" . }}-app-dr }
+spec:
+host: {{ include "sentiment-app-chart.fullname" . }}-app
+subsets:
+- name: v1
+labels: { version: v1 }
+- name: v2
+labels: { version: v2 }

--- a/sentiment-app-chart/templates/gateway.yaml
+++ b/sentiment-app-chart/templates/gateway.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+    name: {{ include "sentiment-app-chart.fullname" . }}-gateway
+    namespace: {{ include "sentiment-app-chart.namespace" . }}
+spec:
+    selector: { istio: ingressgateway }
+    servers:
+    - port: { number: 80, name: http, protocol: HTTP }
+        hosts: [ "*" ]

--- a/sentiment-app-chart/templates/gateway.yaml
+++ b/sentiment-app-chart/templates/gateway.yaml
@@ -2,9 +2,8 @@ apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
     name: {{ include "sentiment-app-chart.fullname" . }}-gateway
-    namespace: {{ include "sentiment-app-chart.namespace" . }}
 spec:
     selector: { istio: ingressgateway }
     servers:
     - port: { number: 80, name: http, protocol: HTTP }
-        hosts: [ "*" ]
+      hosts: [ "*" ]

--- a/sentiment-app-chart/templates/model-deployment.yaml
+++ b/sentiment-app-chart/templates/model-deployment.yaml
@@ -1,24 +1,70 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "sentiment-app-chart.fullname" . }}-model-service
+  name: {{ include "sentiment-app-chart.fullname" . }}-model-service-v1
   labels:
     {{- include "sentiment-app-chart.labels" . | nindent 4 }}
+    version: v1
 spec:
   replicas: {{ .Values.replica_count }}
   selector:
     matchLabels:
       app: {{ include "sentiment-app-chart.fullname" . }}-model-service
       {{- include "sentiment-app-chart.selectorLabels" . | nindent 6 }}
+      version: v1
   template:
     metadata:
       labels:
         app: {{ include "sentiment-app-chart.fullname" . }}-model-service
         {{- include "sentiment-app-chart.selectorLabels" . | nindent 8 }}
+        version: v1
     spec:
       containers:
         - name: {{ include "sentiment-app-chart.fullname" . }}-model-service
           image: "{{ .Values.modelService.image }}:{{ .Values.modelService.tag }}"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+          envFrom:
+            - configMapRef:
+                name: {{ include "sentiment-app-chart.fullname" . }}-model-env
+          volumeMounts:
+            - name: model-cache
+              mountPath: /app/model-cache
+            - name: cv-cache
+              mountPath: /app/cv-cache
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: {{ include "sentiment-app-chart.fullname" . }}-model-cache
+        - name: cv-cache
+          persistentVolumeClaim:
+            claimName: {{ include "sentiment-app-chart.fullname" . }}-cv-cache
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sentiment-app-chart.fullname" . }}-model-service-v2
+  labels:
+    {{- include "sentiment-app-chart.labels" . | nindent 4 }}
+    version: v2
+spec:
+  replicas: {{ .Values.replica_count }}
+  selector:
+    matchLabels:
+      app: {{ include "sentiment-app-chart.fullname" . }}-model-service
+      {{- include "sentiment-app-chart.selectorLabels" . | nindent 6 }}
+      version: v2
+  template:
+    metadata:
+      labels:
+        app: {{ include "sentiment-app-chart.fullname" . }}-model-service
+        {{- include "sentiment-app-chart.selectorLabels" . | nindent 8 }}
+        version: v2
+    spec:
+      containers:
+        - name: {{ include "sentiment-app-chart.fullname" . }}-model-service
+          image: "{{ .Values.modelService.image }}:{{ .Values.modelService.tagv2 }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 80

--- a/sentiment-app-chart/templates/model-service-destination-rule.yaml
+++ b/sentiment-app-chart/templates/model-service-destination-rule.yaml
@@ -2,9 +2,9 @@ apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata: { name: {{ include "sentiment-app-chart.fullname" . }}-model-service-dr }
 spec:
-host: {{ include "sentiment-app-chart.fullname" . }}-model-service
-subsets:
-- name: v1
-labels: { version: v1 }
-- name: v2
-labels: { version: v2 }
+    host: {{ include "sentiment-app-chart.fullname" . }}-model-service
+    subsets:
+    - name: v1
+      labels: { version: v1 }
+    - name: v2
+      labels: { version: v2 }

--- a/sentiment-app-chart/templates/model-service-destination-rule.yaml
+++ b/sentiment-app-chart/templates/model-service-destination-rule.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata: { name: {{ include "sentiment-app-chart.fullname" . }}-model-service-dr }
+spec:
+host: {{ include "sentiment-app-chart.fullname" . }}-model-service
+subsets:
+- name: v1
+labels: { version: v1 }
+- name: v2
+labels: { version: v2 }

--- a/sentiment-app-chart/templates/model-service-virtualservice.yaml
+++ b/sentiment-app-chart/templates/model-service-virtualservice.yaml
@@ -5,8 +5,8 @@ spec:
     hosts: [ {{ include "sentiment-app-chart.fullname" . }}-model-service ]
     http:
     - match:
-        - sourceLabels: { version: v2 }
-        route:
-        - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-model-service, subset: v2 }
+      - sourceLabels: { version: v2 }
+      route:
+      - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-model-service, subset: v2 }
     - route:
-        - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-model-service, subset: v1 }
+      - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-model-service, subset: v1 }

--- a/sentiment-app-chart/templates/model-service-virtualservice.yaml
+++ b/sentiment-app-chart/templates/model-service-virtualservice.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata: { name: {{ include "sentiment-app-chart.fullname" . }}-model-service-virtualservice }
+spec:
+    hosts: [ {{ include "sentiment-app-chart.fullname" . }}-model-service ]
+    http:
+    - match:
+        - sourceLabels: { version: v2 }
+        route:
+        - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-model-service, subset: v2 }
+    - route:
+        - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-model-service, subset: v1 }

--- a/sentiment-app-chart/templates/virtualservice.yaml
+++ b/sentiment-app-chart/templates/virtualservice.yaml
@@ -7,8 +7,8 @@ spec:
     http:
     - match:
         - uri: { prefix: / }
-        route:
-        - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-app, subset: v1 }
-            weight: 90
-        - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-app, subset: v2 }
-            weight: 10
+      route:
+      - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-app, subset: v1 }
+        weight: 90
+      - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-app, subset: v2 }
+        weight: 10

--- a/sentiment-app-chart/templates/virtualservice.yaml
+++ b/sentiment-app-chart/templates/virtualservice.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata: { name: {{ include "sentiment-app-chart.fullname" . }}-virtualservice }
+spec:
+    gateways: [ {{ include "sentiment-app-chart.fullname" . }}-gateway ]
+    hosts: [ "*" ]
+    http:
+    - match:
+        - uri: { prefix: / }
+        route:
+        - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-app, subset: v1 }
+            weight: 90
+        - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-app, subset: v2 }
+            weight: 10

--- a/sentiment-app-chart/templates/virtualservice.yaml
+++ b/sentiment-app-chart/templates/virtualservice.yaml
@@ -6,6 +6,28 @@ spec:
     hosts: [ "*" ]
     http:
     - match:
+        - headers:
+            x-experiment:
+              exact: "true"
+          uri:
+            prefix: /
+      route:
+        - destination:
+            host: {{ include "sentiment-app-chart.fullname" . }}-app
+            subset: v2
+          weight: 100
+    - match:
+        - headers:
+            x-experiment:
+              exact: "false"
+          uri:
+            prefix: /
+      route:
+        - destination:
+            host: {{ include "sentiment-app-chart.fullname" . }}-app
+            subset: v1
+          weight: 100
+    - match:
         - uri: { prefix: / }
       route:
       - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-app, subset: v1 }

--- a/sentiment-app-chart/values.yaml
+++ b/sentiment-app-chart/values.yaml
@@ -4,11 +4,13 @@ app:
   image: ghcr.io/remla25-team5/app
   tag: latest
   port: 8080
+  tagv2: latest
 
 modelService:
   image: ghcr.io/remla25-team5/model-service
   tag: latest
   port: 5000
+  tagv2: latest
   
 persistentVolumeSize: 100Mi
 

--- a/sentiment-app-chart/values.yaml
+++ b/sentiment-app-chart/values.yaml
@@ -4,13 +4,13 @@ app:
   image: ghcr.io/remla25-team5/app
   tag: latest
   port: 8080
-  tagv2: latest
+  tagv2: v2.latest
 
 modelService:
   image: ghcr.io/remla25-team5/model-service
   tag: latest
   port: 5000
-  tagv2: latest
+  tagv2: v2.latest
   
 persistentVolumeSize: 100Mi
 
@@ -25,3 +25,16 @@ grafana:
   ingress:
     host: grafana.local
     servicePort: 80
+
+
+kube-prometheus-stack:
+  prometheusOperator:
+    admissionWebhooks:
+    # Istio tries to inject sidecars into all pods, including those managed by the Prometheus Operator.
+    # The prometheus certificate generation pods created are temporary and the sidecar injection tries to continue to run even tho the pod has exited.
+    # This causes the intallation to timeout as the sidecar injection tries to inject into pods that are not running.
+    # To avoid this, we disable the sidecar injection for the temporary webhook pods created by the Prometheus Operator.
+      patch:
+        enabled: true 
+        podAnnotations:
+          sidecar.istio.io/inject: "false"


### PR DESCRIPTION
This pull request introduces Istio integration for traffic management and canary deployments, along with updates to the Helm chart for versioned deployments of both the app and model-service. It also includes documentation updates to guide users on using Istio with the Helm chart.

### Istio Integration and Traffic Management:
* Added `Gateway`, `VirtualService`, and `DestinationRule` resources for Istio to enable traffic routing and canary deployments for the app and model-service. This includes support for sticky sessions to fulfill the **excellent requirement**.

### Helm Chart Updates:
* Updated `app-deployment.yaml` and `model-deployment.yaml` to include versioned deployments (`v1` and `v2`) for both the app and model-service, enabling Istio to differentiate between versions.
* Added new image tags (`tagv2`) in `values.yaml` to support versioning for the app and model-service.

**TODO in the future**: 
* Add support for Vagrant. This will be done once the `finalization.yml` from W2 is fixed and Step 23 is implemented.
* Update tags in `values.yaml` to reflect our `v1` and `v2` images.

Closes #30 