### PR TITLE
Step 23, fix SSH, flannel (step 20)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ BOX_IMAGE = "bento/ubuntu-24.04"
 BOX_VERSION = "202502.21.0"
 
 # Number of worker nodes
-NODE_COUNT = 1
+NODE_COUNT = 2
 
 # Number of CPUs and memory for the controller node
 CTRL_CPUS = 2 # This was changed from 1 to 2 due to step 13

--- a/ansible-provisioning/ctrl.yaml
+++ b/ansible-provisioning/ctrl.yaml
@@ -72,18 +72,9 @@
 
 # Step 15: Install Flannel network plugin
     - name: "Download Flannel CNI manifest"
-      get_url:
-        url: https://raw.githubusercontent.com/flannel-io/flannel/v0.26.7/Documentation/kube-flannel.yml
+      ansible.builtin.copy:
+        src: kube-flannel.yml
         dest: /tmp/kube-flannel.yml
-
-    - name: "Patch Flannel manifest with --iface=eth1"
-      replace:
-        path: /tmp/kube-flannel.yml
-        regexp: 'args:\s*\n\s*- "--ip-masq"'
-        replace: |
-          args:
-            - "--ip-masq"
-            - "--iface=eth1"
 
     - name: "Apply Flannel network plugin to the cluster"
       command: kubectl apply -f /tmp/kube-flannel.yml

--- a/ansible-provisioning/finalization.yaml
+++ b/ansible-provisioning/finalization.yaml
@@ -207,3 +207,33 @@
       vars:
         nginx_ingress_loadbalancer_ip: "192.168.56.90"
 
+    # Step 23: Install Istio
+    - name: Download Istio-1.25.2 and unpack it
+      ansible.builtin.unarchive:
+        src: https://github.com/istio/istio/releases/download/1.25.2/istio-1.25.2-linux-amd64.tar.gz
+        dest: /usr/local/bin
+        remote_src: yes
+    - name: Add the istioctl binary to the PATH variable
+      ansible.builtin.copy:
+        src: /usr/local/bin/istio-1.25.2/bin/istioctl
+        dest: /usr/local/bin/istioctl
+        remote_src: yes
+        mode: "0755"
+    - name: IstioOperator
+      ansible.builtin.copy:
+        content: |
+          apiVersion: install.istio.io/v1alpha1
+          kind: IstioOperator
+          spec:
+            components:
+              ingressGateways:
+              - name: istio-ingressgateway
+                enabled: true
+                k8s:
+                  service:
+                    loadBalancerIP: 192.168.56.91
+        dest: config.yml
+    - name: Install Istio
+      ansible.builtin.shell: istioctl install -y -f config.yml
+    - name: Enable Istio
+      ansible.builtin.shell: kubectl label ns default istio-injection=enabled

--- a/ansible-provisioning/finalization.yaml
+++ b/ansible-provisioning/finalization.yaml
@@ -40,7 +40,7 @@
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: {{ dashboard_service_account_name }}-cluster-admin
+        name: {{ dashboard_service_account_name }}
       subjects:
       - kind: ServiceAccount
         name: {{ dashboard_service_account_name }}
@@ -182,7 +182,12 @@
         dest: "/tmp/dashboard-ingress.yaml"
         mode: '0644'
 
-    - name: "Apply Ingress for {{ dashboard_hostname }}"
+    - name: Wait ingress-nginx
+      ansible.builtin.shell: kubectl wait -n {{ nginx_ingress_repo_name|quote }} --all --for=condition=ready pod --timeout=60s
+    - name: Wait kubernetes-dashboard
+      ansible.builtin.shell: kubectl wait -n {{ dashboard_namespace|quote }} --all --for=condition=ready pod --timeout=60s
+
+    - name: "Apply Ingress for dashboard.local"
       ansible.builtin.command: >
         kubectl apply -f /tmp/dashboard-ingress.yaml
  
@@ -197,8 +202,8 @@
         msg:
           - "To log into the Dashboard, get the token for '{{ dashboard_service_account_name }}' manually."
           - "Run on the ctrl VM: kubectl -n {{ dashboard_namespace }} create token {{ dashboard_service_account_name }}" 
-          - "Access Dashboard at: https://{{ dashboard_hostname }}"
-          - "Remember to add '{{ nginx_ingress_loadbalancer_ip }} {{ dashboard_hostname }}' to your host's DNS file."
+          - "Access Dashboard at: https://dashboard.local"
+          - "Remember to add '{{ nginx_ingress_loadbalancer_ip }} dashboard.local' to your host's DNS file."
       vars:
         nginx_ingress_loadbalancer_ip: "192.168.56.90"
 

--- a/ansible-provisioning/general.yaml
+++ b/ansible-provisioning/general.yaml
@@ -29,42 +29,6 @@
         var: ssh_key_result
       when: ssh_key_result is defined
 
-    # ChatGPT helped with fixing the SSH key authorization issue in Step 18
-    # Enable SSH between nodes without password prompts
-    - name: Create SSH directory if it doesn't exist
-      file:
-        path: /home/vagrant/.ssh
-        state: directory
-        mode: '0700'
-        owner: vagrant
-        group: vagrant
-
-    - name: Generate SSH key for vagrant user if not exists
-      user:
-        name: vagrant
-        generate_ssh_key: yes
-        ssh_key_type: rsa
-        ssh_key_bits: 2048
-      become: yes
-      become_user: vagrant
-      register: ssh_key_gen
-
-    - name: Get content of vagrant user's public key
-      slurp:
-        src: /home/vagrant/.ssh/id_rsa.pub
-      register: pubkey_content
-      become: yes
-      become_user: vagrant
-
-    - name: Share public key with all hosts
-      authorized_key:
-        user: vagrant
-        state: present
-        key: "{{ hostvars[item]['pubkey_content']['content'] | b64decode }}"
-      loop: "{{ ansible_play_hosts }}"
-      when: hostvars[item]['pubkey_content'] is defined
-      ignore_errors: yes
-
     # Step 5: Disable Swap
     - name: Disable swap temporarily
       shell: swapoff -a
@@ -94,8 +58,11 @@
 
     - name: Load br_netfilter module now
       community.general.modprobe:
-        name: br_netfilter
+        name: "{{ item }}"
         state: present
+      loop:
+        - br_netfilter
+        - overlay
 
     # Step 7: Set Kernel Parameters
     - name: Enable required sysctl parameters for Kubernetes networking

--- a/ansible-provisioning/inventory.cfg
+++ b/ansible-provisioning/inventory.cfg
@@ -3,6 +3,7 @@ ctrl ansible_host=192.168.56.100 ansible_ssh_private_key_file=./.vagrant/machine
 
 [nodes]
 node-1 ansible_host=192.168.56.101 ansible_ssh_private_key_file=./.vagrant/machines/node-1/virtualbox/private_key ansible_ssh_common_args='-o IdentitiesOnly=yes'
+node-2 ansible_host=192.168.56.102 ansible_ssh_private_key_file=./.vagrant/machines/node-2/virtualbox/private_key ansible_ssh_common_args='-o IdentitiesOnly=yes'
 
 [all:children]
 controller

--- a/ansible-provisioning/inventory.cfg
+++ b/ansible-provisioning/inventory.cfg
@@ -1,9 +1,8 @@
 [controller]
-ctrl ansible_host=192.168.56.100
+ctrl ansible_host=192.168.56.100 ansible_ssh_private_key_file=./.vagrant/machines/ctrl/virtualbox/private_key ansible_ssh_common_args='-o IdentitiesOnly=yes'
 
 [nodes]
-node-1 ansible_host=192.168.56.101
-node-2 ansible_host=192.168.56.102
+node-1 ansible_host=192.168.56.101 ansible_ssh_private_key_file=./.vagrant/machines/node-1/virtualbox/private_key ansible_ssh_common_args='-o IdentitiesOnly=yes'
 
 [all:children]
 controller
@@ -11,5 +10,3 @@ nodes
 
 [all:vars]
 ansible_user=vagrant
-ansible_ssh_private_key_file=/home/vagrant/.ssh/id_rsa
-ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'

--- a/ansible-provisioning/kube-flannel.yml
+++ b/ansible-provisioning/kube-flannel.yml
@@ -1,0 +1,213 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    k8s-app: flannel
+    pod-security.kubernetes.io/enforce: privileged
+  name: kube-flannel
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: flannel
+  name: flannel
+  namespace: kube-flannel
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: flannel
+  name: flannel
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: flannel
+  name: flannel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flannel
+subjects:
+- kind: ServiceAccount
+  name: flannel
+  namespace: kube-flannel
+---
+apiVersion: v1
+data:
+  cni-conf.json: |
+    {
+      "name": "cbr0",
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "flannel",
+          "delegate": {
+            "hairpinMode": true,
+            "isDefaultGateway": true
+          }
+        },
+        {
+          "type": "portmap",
+          "capabilities": {
+            "portMappings": true
+          }
+        }
+      ]
+    }
+  net-conf.json: |
+    {
+      "Network": "10.244.0.0/16",
+      "EnableNFTables": false,
+      "Backend": {
+        "Type": "vxlan"
+      }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: flannel
+    k8s-app: flannel
+    tier: node
+  name: kube-flannel-cfg
+  namespace: kube-flannel
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: flannel
+    k8s-app: flannel
+    tier: node
+  name: kube-flannel-ds
+  namespace: kube-flannel
+spec:
+  selector:
+    matchLabels:
+      app: flannel
+      k8s-app: flannel
+  template:
+    metadata:
+      labels:
+        app: flannel
+        k8s-app: flannel
+        tier: node
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - args:
+        - --ip-masq
+        - --kube-subnet-mgr
+        - --iface=eth1
+        command:
+        - /opt/bin/flanneld
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: EVENT_QUEUE_DEPTH
+          value: "5000"
+        image: ghcr.io/flannel-io/flannel:v0.26.7
+        name: kube-flannel
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - NET_RAW
+          privileged: false
+        volumeMounts:
+        - mountPath: /run/flannel
+          name: run
+        - mountPath: /etc/kube-flannel/
+          name: flannel-cfg
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+      hostNetwork: true
+      initContainers:
+      - args:
+        - -f
+        - /flannel
+        - /opt/cni/bin/flannel
+        command:
+        - cp
+        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.6.2-flannel1
+        name: install-cni-plugin
+        volumeMounts:
+        - mountPath: /opt/cni/bin
+          name: cni-plugin
+      - args:
+        - -f
+        - /etc/kube-flannel/cni-conf.json
+        - /etc/cni/net.d/10-flannel.conflist
+        command:
+        - cp
+        image: ghcr.io/flannel-io/flannel:v0.26.7
+        name: install-cni
+        volumeMounts:
+        - mountPath: /etc/cni/net.d
+          name: cni
+        - mountPath: /etc/kube-flannel/
+          name: flannel-cfg
+      priorityClassName: system-node-critical
+      serviceAccountName: flannel
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /run/flannel
+        name: run
+      - hostPath:
+          path: /opt/cni/bin
+        name: cni-plugin
+      - hostPath:
+          path: /etc/cni/net.d
+        name: cni
+      - configMap:
+          name: kube-flannel-cfg
+        name: flannel-cfg
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock


### PR DESCRIPTION
At least for me, vagrant up never have finished successfully from the first try, it always failed on delegate_to step (Step 18). Moreover, found that Step 15: Install Flannel network plugin was the root cause why IPAdressPool wasn't created later (regexp didn't replace args as expected). Also added some extra kubectl waits before applying ingress as it was failing presumably because eithe k8s dashboard or nginx ingress controller pods were not ready.