### PR TITLE
Fix installing without istio

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,14 @@ istioctl install
 kubectl apply -f istio-1.26.0/samples/addons/jaeger.yaml
 kubectl apply -f istio-1.26.0/samples/addons/kiali.yaml
 kubectl label ns default istio-injection=enabled
+
+cd ./sentiment-app-chart
+helm dependency build
+cd ..
+
+# Install the Helm chart (optionally, Gmail inbox and App password https://support.google.com/accounts/answer/185833?hl=en are needed for receiving alerts)
+# Default enabled Istio
+helm install sentiment-app ./sentiment-app-chart --set monitoring.enabled=true --set gmailEmail=<value>@gmail.com --set emailPassword=<value>
 ```
 If running the cluster on VM, don't forget to execute the following commands for convenience (192.168.56.91 is Istio load balancer IP):
 ```bash

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ helm dependency build
 cd ..
 
 # Install the Helm chart (optionally, Gmail inbox and App password https://support.google.com/accounts/answer/185833?hl=en are needed for receiving alerts)
-helm install sentiment-app ./sentiment-app-chart --set monitoring.enabled=true --set gmailEmail=<value>@gmail.com --set emailPassword=<value>
+helm install sentiment-app ./sentiment-app-chart --set monitoring.enabled=true --set istioEnabled=false --set gmailEmail=<value>@gmail.com --set emailPassword=<value>
 
 # Verify the deployment
 kubectl get pods

--- a/README.md
+++ b/README.md
@@ -345,7 +345,8 @@ If no header is present (`x-experiment` not sent), Istio **dynamically splits tr
 * **90%** of users will be routed to `v1`.
 * **10%** will see `v2`.
 
-You can verify this by repeatedly refreshing the page or sending multiple curl requests without the header.
+The version is set using a cookie on first entrance on the web, so repeatedly refreshing will not work. This makes it hard to see the feature version (v2), so to see this we recommend setting the `x-experiment: true` header. 
+This can be done in a browser using an extension such as ModHeader for google chrome: https://chromewebstore.google.com/detail/modheader-modify-http-hea/idgpnmonknjnojddfkpgkljpfnnfcklj?pli=1
 
 To test rate limiting, call 
 ```bash

--- a/sentiment-app-chart/templates/app-deployment.yaml
+++ b/sentiment-app-chart/templates/app-deployment.yaml
@@ -40,6 +40,7 @@ spec:
         - name: shared-data
           hostPath:
             path: /mnt/shared
+{{- if .Values.istioEnabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -83,3 +84,4 @@ spec:
         - name: shared-data
           hostPath:
             path: /mnt/shared
+{{- end }}

--- a/sentiment-app-chart/templates/app-destination-rule.yaml
+++ b/sentiment-app-chart/templates/app-destination-rule.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.istioEnabled }}
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata: { name: {{ include "sentiment-app-chart.fullname" . }}-app-dr }
@@ -8,3 +9,4 @@ spec:
       labels: { version: v1 }
     - name: v2
       labels: { version: v2 }
+{{- end }}

--- a/sentiment-app-chart/templates/app-virtualservice.yaml
+++ b/sentiment-app-chart/templates/app-virtualservice.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.istioEnabled }}
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata: { name: {{ include "sentiment-app-chart.fullname" . }}-virtualservice }
@@ -58,3 +59,4 @@ spec:
       - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-app, subset: v2 }
         weight: 10
       name: api
+{{- end }}

--- a/sentiment-app-chart/templates/gateway.yaml
+++ b/sentiment-app-chart/templates/gateway.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.istioEnabled }}
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
@@ -7,3 +8,4 @@ spec:
     servers:
     - port: { number: 80, name: http, protocol: HTTP }
       hosts: [ "*" ]
+{{- end}}

--- a/sentiment-app-chart/templates/gmail-secret.yaml
+++ b/sentiment-app-chart/templates/gmail-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.monitoring.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,3 +6,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
 stringData:
   appPassword: "{{ .Values.emailPassword }}"
+{{- end }}

--- a/sentiment-app-chart/templates/grafana-ingress.yaml
+++ b/sentiment-app-chart/templates/grafana-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.monitoring.enabled (not .Values.grafana.ingress.useIstio) }}
+{{- if and .Values.monitoring.enabled (not .Values.istioEnabled) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/sentiment-app-chart/templates/ingress.yaml
+++ b/sentiment-app-chart/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if (not .Values.grafana.ingress.useIstio) }}
+{{- if (not .Values.istioEnabled) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/sentiment-app-chart/templates/istio-grafana-virtualservice.yaml
+++ b/sentiment-app-chart/templates/istio-grafana-virtualservice.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.monitoring.enabled }}
+{{- if and .Values.monitoring.enabled .Values.istioEnabled }}
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:

--- a/sentiment-app-chart/templates/model-deployment.yaml
+++ b/sentiment-app-chart/templates/model-deployment.yaml
@@ -28,6 +28,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "sentiment-app-chart.fullname" . }}-model-env
+{{- if .Values.istioEnabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -59,3 +60,4 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "sentiment-app-chart.fullname" . }}-model-env
+{{- end }}

--- a/sentiment-app-chart/templates/model-service-destination-rule.yaml
+++ b/sentiment-app-chart/templates/model-service-destination-rule.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.istioEnabled }}
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata: { name: {{ include "sentiment-app-chart.fullname" . }}-model-service-dr }
@@ -8,3 +9,4 @@ spec:
       labels: { version: v1 }
     - name: v2
       labels: { version: v2 }
+{{- end }}

--- a/sentiment-app-chart/templates/model-service-virtualservice.yaml
+++ b/sentiment-app-chart/templates/model-service-virtualservice.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.istioEnabled }}
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata: { name: {{ include "sentiment-app-chart.fullname" . }}-model-service-virtualservice }
@@ -10,3 +11,4 @@ spec:
       - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-model-service, subset: v2 }
     - route:
       - destination: { host: {{ include "sentiment-app-chart.fullname" . }}-model-service, subset: v1 }
+{{- end }}

--- a/sentiment-app-chart/templates/rate-limiting.yaml
+++ b/sentiment-app-chart/templates/rate-limiting.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.istioEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -204,3 +205,4 @@ spec:
               - request_headers:
                   header_name: "x-user"
                   descriptor_key: "x-user"
+{{- end }}

--- a/sentiment-app-chart/values.yaml
+++ b/sentiment-app-chart/values.yaml
@@ -25,8 +25,8 @@ grafana:
   ingress:
     host: grafana.local
     servicePort: 80
-    useIstio: true
   
+istioEnabled: true
 
 
 kube-prometheus-stack:


### PR DESCRIPTION
Now you can run the helm chart without istio with no problem using the tag istioEnabled=false as stated in the README.md